### PR TITLE
Reduce temperature bands from 7 to 5 per side

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,21 +15,17 @@
   </head>
   <body>
     <main class="clima column">
-      <div id="hot-7" class="temperature hot" style="--index: 0;"></div>
-      <div id="hot-6" class="temperature hot" style="--index: 1;"></div>
-      <div id="hot-5" class="temperature hot" style="--index: 2;"></div>
-      <div id="hot-4" class="temperature hot" style="--index: 3;"></div>
-      <div id="hot-3" class="temperature hot" style="--index: 4;"></div>
-      <div id="hot-2" class="temperature hot" style="--index: 5;"></div>
-      <div id="hot-1" class="temperature hot" style="--index: 6;"></div>
+      <div id="hot-5" class="temperature hot" style="--index: 0;"></div>
+      <div id="hot-4" class="temperature hot" style="--index: 1;"></div>
+      <div id="hot-3" class="temperature hot" style="--index: 2;"></div>
+      <div id="hot-2" class="temperature hot" style="--index: 3;"></div>
+      <div id="hot-1" class="temperature hot" style="--index: 4;"></div>
       <div id="normal" class="temperature normal"></div>
       <div id="cold-1" class="temperature cold" style="--index: 0;"></div>
       <div id="cold-2" class="temperature cold" style="--index: 1;"></div>
       <div id="cold-3" class="temperature cold" style="--index: 2;"></div>
       <div id="cold-4" class="temperature cold" style="--index: 3;"></div>
       <div id="cold-5" class="temperature cold" style="--index: 4;"></div>
-      <div id="cold-6" class="temperature cold" style="--index: 5;"></div>
-      <div id="cold-7" class="temperature cold" style="--index: 6;"></div>
     </main>
     <!-- <main class="clima" style="display:flex;gap:8px;">
       <div class="column" style="flex:1">

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -6,8 +6,7 @@
     flex: 1;
 
     &.hot {
-      background-color: color-mix(in oklch, var(--warm-start) calc((6 - var(--index)) / 6 * 100%), var(--warm-end) calc(var(--index) / 6 * 100%));
-      /* background-color: color-mix(in oklch, var(--warm-start) calc((7 - var(--index)) / 7 * 100%), var(--warm-end) calc(var(--index) / 7 * 100%)); */
+      background-color: color-mix(in oklch, var(--warm-start) calc((4 - var(--index)) / 4 * 100%), var(--warm-end) calc(var(--index) / 4 * 100%));
     }
 
     &.normal {
@@ -18,8 +17,7 @@
     }
 
     &.cold {
-      background-color: color-mix(in oklch, var(--cold-start) calc((6 - var(--index)) / 6 * 100%), var(--cold-end) calc(var(--index) / 6 * 100%));
-      /* background-color: color-mix(in oklch, var(--cold-start) calc((7 - var(--index)) / 7 * 100%), var(--cold-end) calc(var(--index) / 7 * 100%)); */
+      background-color: color-mix(in oklch, var(--cold-start) calc((4 - var(--index)) / 4 * 100%), var(--cold-end) calc(var(--index) / 4 * 100%));
     }
 
     &.active {

--- a/src/js/clima.js
+++ b/src/js/clima.js
@@ -70,27 +70,21 @@ function isLoading(isLoading) {
 }
 
 // Temperature ranges (Fahrenheit) mapped to section IDs
-// >105: hot-7, 100-105: hot-6, 95-100: hot-5, 90-95: hot-4
-// 85-90: hot-3, 80-85: hot-2, 75-80: hot-1
-// 70-75: normal
-// 65-70: cold-1, 60-65: cold-2, 55-60: cold-3, 50-55: cold-4
-// 45-50: cold-5, 40-45: cold-6, <40: cold-7
+// >95: hot-5, >88: hot-4, >81: hot-3, >77: hot-2, >73: hot-1
+// 66-73: normal
+// >59: cold-1, >52: cold-2, >45: cold-3, >38: cold-4, <=38: cold-5
 function determineSectionId(temp) {
-  if (temp > 105) return 'hot-7';
-  if (temp > 100) return 'hot-6';
   if (temp > 95)  return 'hot-5';
-  if (temp > 90)  return 'hot-4';
-  if (temp > 85)  return 'hot-3';
-  if (temp > 80)  return 'hot-2';
-  if (temp > 75)  return 'hot-1';
-  if (temp >= 70) return 'normal';
-  if (temp >= 65) return 'cold-1';
-  if (temp >= 60) return 'cold-2';
-  if (temp >= 55) return 'cold-3';
-  if (temp >= 50) return 'cold-4';
-  if (temp >= 45) return 'cold-5';
-  if (temp >= 40) return 'cold-6';
-  return 'cold-7';
+  if (temp > 88)  return 'hot-4';
+  if (temp > 81)  return 'hot-3';
+  if (temp > 77)  return 'hot-2';
+  if (temp > 73)  return 'hot-1';
+  if (temp >= 66) return 'normal';
+  if (temp >= 59) return 'cold-1';
+  if (temp >= 52) return 'cold-2';
+  if (temp >= 45) return 'cold-3';
+  if (temp >= 38) return 'cold-4';
+  return 'cold-5';
 }
 
 function updateUI(temp, apparentTemp, location, weatherCode) {


### PR DESCRIPTION
## Summary
- Reduces bands from 15 (7+1+7) to 11 (5+1+5) for a cleaner visual
- Each band now covers ~7°F instead of 5°F, with the normal band spanning 66–73°F
- Updates `color-mix()` divisors in CSS to match the new 0–4 index range

## Test plan
- [ ] Open `index.html` in a browser and verify 11 bands render with a smooth orange → white → blue gradient
- [ ] Allow geolocation and confirm the correct band activates for the current apparent temperature
- [ ] Verify the hottest band is deep orange and coldest is deep blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)