### PR TITLE
Add daily min/max temperatures

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -55,14 +55,26 @@
       }
     }
 
-    .forecast-extreme {
-      font-size: 1.8rem;
-      font-weight: normal;
+    .forecast-range {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      gap: 0.4rem;
       opacity: 0.6;
+    }
+
+    .forecast-extreme {
+      font-size: 1.4rem;
+      font-weight: normal;
 
       &:after {
         content: '\00b0';
       }
+    }
+
+    .forecast-range-separator {
+      font-size: 1.4rem;
+      font-weight: normal;
     }
   }
 

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -52,7 +52,16 @@
 
       &:after {
         content: '\00b0';
-        position: absolute;
+      }
+    }
+
+    .forecast-extreme {
+      font-size: 1.8rem;
+      font-weight: normal;
+      opacity: 0.6;
+
+      &:after {
+        content: '\00b0';
       }
     }
   }

--- a/src/js/clima.js
+++ b/src/js/clima.js
@@ -105,11 +105,14 @@ function updateUI(temp, apparentTemp, location, weatherCode, minTemp, maxTemp) {
   const current = document.createElement('div');
   current.className = 'current column';
   current.innerHTML = `
-    <div class="weather-main">
+    <div class="forecast-range">
       <span class="forecast-extreme forecast-low">${minTemp}</span>
+      <span class="forecast-range-separator">/</span>
+      <span class="forecast-extreme forecast-high">${maxTemp}</span>
+    </div>
+    <div class="weather-main">
       <i class="wi ${weatherCodeToIcon(weatherCode)} weather-icon"></i>
       <div class="forecast">${temp}</div>
-      <span class="forecast-extreme forecast-high">${maxTemp}</span>
     </div>
     <h1 class="location">${location}</h1>
   `;

--- a/src/js/clima.js
+++ b/src/js/clima.js
@@ -1,11 +1,13 @@
 async function getWeather(lat, lon) {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,weather_code&temperature_unit=fahrenheit`;
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,weather_code&daily=temperature_2m_max,temperature_2m_min&temperature_unit=fahrenheit&timezone=auto`;
   const res = await fetch(url);
   const data = await res.json();
   return {
     temp: Math.round(data.current.temperature_2m),
     apparentTemp: Math.round(data.current.apparent_temperature),
     weatherCode: data.current.weather_code,
+    minTemp: Math.round(data.daily.temperature_2m_min[0]),
+    maxTemp: Math.round(data.daily.temperature_2m_max[0]),
   };
 }
 
@@ -87,7 +89,7 @@ function determineSectionId(temp) {
   return 'cold-5';
 }
 
-function updateUI(temp, apparentTemp, location, weatherCode) {
+function updateUI(temp, apparentTemp, location, weatherCode, minTemp, maxTemp) {
   // Remove active state and content from the previous section
   const prev = document.querySelector('.temperature.active');
   if (prev) {
@@ -104,8 +106,10 @@ function updateUI(temp, apparentTemp, location, weatherCode) {
   current.className = 'current column';
   current.innerHTML = `
     <div class="weather-main">
+      <span class="forecast-extreme forecast-low">${minTemp}</span>
       <i class="wi ${weatherCodeToIcon(weatherCode)} weather-icon"></i>
       <div class="forecast">${temp}</div>
+      <span class="forecast-extreme forecast-high">${maxTemp}</span>
     </div>
     <h1 class="location">${location}</h1>
   `;
@@ -119,10 +123,10 @@ async function init() {
     const { latitude, longitude } = coords;
     const { address: { city, state } } = address;
 
-    const { temp, apparentTemp, weatherCode } = await getWeather(latitude, longitude);
+    const { temp, apparentTemp, weatherCode, minTemp, maxTemp } = await getWeather(latitude, longitude);
 
     isLoading(false);
-    updateUI(temp, apparentTemp, `${city}, ${state}`, weatherCode);
+    updateUI(temp, apparentTemp, `${city}, ${state}`, weatherCode, minTemp, maxTemp);
   } catch (err) {
     console.log(err);
     // show error in UI


### PR DESCRIPTION
## Summary
- Fetch today's high and low from Open-Meteo's `daily` endpoint (with `timezone=auto` so "today" matches the user's local day).
- Render min and max as smaller, lower-contrast values flanking the current temperature inside `.weather-main`.
- Drop `position: absolute` from `.forecast:after` so the degree symbol no longer overlaps the new max value.

## Test plan
- [ ] Serve `index.html`, approve geolocation, and confirm min/current/max render in order with degree symbols.
- [ ] Verify min ≤ current ≤ max against the Open-Meteo response in DevTools → Network.
- [ ] Spot-check a hot stripe and a cold stripe (e.g. hardcoded coords) so the `opacity: 0.6` styling reads on both palettes.

## Before
<img width="385" height="117" alt="Screenshot 2026-04-11 at 1 39 29 PM" src="https://github.com/user-attachments/assets/c4b24c07-52ba-40c8-a25e-e42c2970293a" />

## After
<img width="351" height="139" alt="Screenshot 2026-04-11 at 2 07 07 PM" src="https://github.com/user-attachments/assets/7f57f97d-46a1-471c-a397-68a808158297" />

## Alternatives
<img width="296" height="115" alt="Screenshot 2026-04-11 at 1 45 54 PM" src="https://github.com/user-attachments/assets/69c9ef93-5a37-4579-a2b3-7cb374d5e445" />

<img width="321" height="115" alt="Screenshot 2026-04-11 at 1 39 39 PM" src="https://github.com/user-attachments/assets/40e82801-5010-4fb3-ab54-54b1a6abae21" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)