### PR TITLE
Add tap-to-reveal 7-day weather forecast

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -76,6 +76,74 @@
       font-size: 1.4rem;
       font-weight: normal;
     }
+
+    cursor: pointer;
+
+    .forecast-toggle-hint {
+      font-size: 1.2rem;
+      opacity: 0.4;
+      transition: transform 0.5s var(--motion-elastic);
+    }
+
+    &.expanded .forecast-toggle-hint {
+      transform: rotate(180deg);
+    }
+
+    .forecast-week {
+      display: flex;
+      justify-content: center;
+      gap: 1.2rem;
+      padding-inline: 1.2rem;
+      height: 0;
+      overflow: hidden;
+      transition: height 0.5s var(--motion-elastic),
+                  margin-top 0.5s var(--motion-elastic);
+      margin-top: 0;
+    }
+
+    &.expanded .forecast-week {
+      height: auto;
+      margin-top: 0.8rem;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+
+    .forecast-week::-webkit-scrollbar {
+      display: none;
+    }
+
+    .forecast-day {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.2rem;
+      min-width: 4.4rem;
+      flex-shrink: 0;
+    }
+
+    .forecast-day-name {
+      font-size: 1.2rem;
+      font-weight: normal;
+      opacity: 0.7;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .forecast-day-icon {
+      font-size: 1.6rem;
+    }
+
+    .forecast-day-high {
+      font-size: 1.2rem;
+      line-height: 1.3;
+    }
+
+    .forecast-day-low {
+      font-size: 1.2rem;
+      font-weight: normal;
+      opacity: 0.5;
+      line-height: 1.3;
+    }
   }
 
   .loader {

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -6,6 +6,9 @@
     --cold-end: #2980b9;
 
     --baseFont: Roboto, Helvetica Neue Light, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+
+    /* --motion-elastic: linear(0, 0.36 15%, 0.98 39%, 1.05 48%, 1.02 58%, 1 68%, 0.99 85%, 1); */
+    --motion-elastic: cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
   html {

--- a/src/js/clima.js
+++ b/src/js/clima.js
@@ -1,5 +1,5 @@
 async function getWeather(lat, lon) {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,weather_code&daily=temperature_2m_max,temperature_2m_min&temperature_unit=fahrenheit&timezone=auto`;
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,weather_code&daily=temperature_2m_max,temperature_2m_min,weather_code&temperature_unit=fahrenheit&timezone=auto`;
   const res = await fetch(url);
   const data = await res.json();
   return {
@@ -8,6 +8,12 @@ async function getWeather(lat, lon) {
     weatherCode: data.current.weather_code,
     minTemp: Math.round(data.daily.temperature_2m_min[0]),
     maxTemp: Math.round(data.daily.temperature_2m_max[0]),
+    daily: data.daily.time.map((dateStr, i) => ({
+      date: dateStr,
+      weatherCode: data.daily.weather_code[i],
+      minTemp: Math.round(data.daily.temperature_2m_min[i]),
+      maxTemp: Math.round(data.daily.temperature_2m_max[i]),
+    })),
   };
 }
 
@@ -26,6 +32,13 @@ function weatherCodeToIcon(code) {
   if (code <= 86)                         return 'wi-snow';
   if (code === 95)                        return 'wi-thunderstorm';
   return 'wi-thunderstorm';
+}
+
+function dayLabel(dateStr) {
+  const date = new Date(dateStr + 'T00:00:00');
+  const today = new Date();
+  if (date.toDateString() === today.toDateString()) return 'Today';
+  return date.toLocaleDateString('en-US', { weekday: 'short' });
 }
 
 async function coordsToCity(lat, lon) {
@@ -89,7 +102,7 @@ function determineSectionId(temp) {
   return 'cold-5';
 }
 
-function updateUI(temp, apparentTemp, location, weatherCode, minTemp, maxTemp) {
+function updateUI(temp, apparentTemp, location, weatherCode, minTemp, maxTemp, daily) {
   // Remove active state and content from the previous section
   const prev = document.querySelector('.temperature.active');
   if (prev) {
@@ -115,7 +128,21 @@ function updateUI(temp, apparentTemp, location, weatherCode, minTemp, maxTemp) {
       <div class="forecast">${temp}</div>
     </div>
     <h1 class="location">${location}</h1>
+    <div class="forecast-toggle-hint">&#x25BE;</div>
+    <div class="forecast-week">
+      ${daily.map(day => `
+        <div class="forecast-day">
+          <span class="forecast-day-name">${dayLabel(day.date)}</span>
+          <i class="wi ${weatherCodeToIcon(day.weatherCode)} forecast-day-icon"></i>
+          <span class="forecast-day-high">${day.maxTemp}&deg;</span>
+          <span class="forecast-day-low">${day.minTemp}&deg;</span>
+        </div>
+      `).join('')}
+    </div>
   `;
+  current.addEventListener('click', () => {
+    current.classList.toggle('expanded');
+  });
   section.appendChild(current);
 }
 
@@ -126,10 +153,10 @@ async function init() {
     const { latitude, longitude } = coords;
     const { address: { city, state } } = address;
 
-    const { temp, apparentTemp, weatherCode, minTemp, maxTemp } = await getWeather(latitude, longitude);
+    const { temp, apparentTemp, weatherCode, minTemp, maxTemp, daily } = await getWeather(latitude, longitude);
 
     isLoading(false);
-    updateUI(temp, apparentTemp, `${city}, ${state}`, weatherCode, minTemp, maxTemp);
+    updateUI(temp, apparentTemp, `${city}, ${state}`, weatherCode, minTemp, maxTemp, daily);
   } catch (err) {
     console.log(err);
     // show error in UI


### PR DESCRIPTION
## Summary
- Extend the Open-Meteo API call to fetch daily weather codes for 7 days (previously only used today's min/max)
- Add a tap-to-reveal forecast row inside the active temperature stripe with day names, weather icons, and high/low temps
- Animate the reveal with an elastic cubic-bezier curve via a `--motion-elastic` design token

## Test plan
- [ ] Serve the app and allow geolocation — default view should be unchanged except for a small chevron below the location
- [ ] Tap the current weather area — forecast row should expand with a smooth elastic animation
- [ ] Tap again to collapse — chevron rotates back
- [ ] First day should show "Today", remaining days show short day names (Mon, Tue, etc.)
- [ ] Verify on a narrow mobile viewport — forecast row should be horizontally scrollable
- [ ] Temperature stripes should render correctly in both collapsed and expanded states

## Screenshots
<img width="416" height="236" alt="Screenshot 2026-04-13 at 10 00 09 PM" src="https://github.com/user-attachments/assets/fb2ca4f1-1157-4616-8fda-8b442396fad6" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)